### PR TITLE
[Discussion] Add an install._expose() method to give access to root.

### DIFF
--- a/install.js
+++ b/install.js
@@ -54,6 +54,13 @@ makeInstaller = function (options) {
     return root.r;
   }
 
+  // Undocumented ability to expose private vars for debugging and experiments.
+  install._expose = function() {
+    return {
+      root: root
+    }
+  }
+
   function getOwn(obj, key) {
     return hasOwn.call(obj, key) && obj[key];
   }


### PR DESCRIPTION
@benjamn, would you consider something along these lines?

Example use case is https://github.com/gadicc/meteor-react-hotloader (which perhaps we could discuss further after the 1.3 final).