### PR TITLE
Enable retrying dynamic imports after failure.

### DIFF
--- a/install.js
+++ b/install.js
@@ -142,6 +142,8 @@ makeInstaller = function (options) {
       // Grab the current missing object and fetch its contents.
       var toBeFetched = missing;
       missing = null;
+      // Grab file so we can reset pending later
+      var file = getOwn(filesByModuleId, absChildId);
 
       return Promise.resolve(
         // The install.fetch function takes an object mapping missing
@@ -154,6 +156,8 @@ makeInstaller = function (options) {
       ).then(function (tree) {
         function both() {
           install(tree);
+          // File has been fetched && installed
+          file.pending = false;
           return absChildId;
         }
 
@@ -165,6 +169,12 @@ makeInstaller = function (options) {
         // Whether previousPromise was resolved or rejected, carry on with
         // the installation regardless.
         return previousPromise.then(both, both);
+      }).catch(function (error) {
+        // File hasn't been fetch, but we need to reset pending, so
+        // condition for checking missing file in prefetch walk
+        // behave appropriately : https://github.com/meteor/meteor/issues/10182
+        file.pending = false;
+        throw new Error(error);
       });
     });
   };

--- a/install.js
+++ b/install.js
@@ -151,15 +151,15 @@ makeInstaller = function (options) {
         }
       }
 
-      return Promise.resolve(
+      return new Promise(function (resolve) {
         // The install.fetch function takes an object mapping missing
         // dynamic module identifiers to options objects, and should
         // return a Promise that resolves to a module tree that can be
         // installed. As an optimization, if there were no missing dynamic
         // modules, then we can skip calling install.fetch entirely.
-        toBeFetched && install.fetch(toBeFetched)
+        resolve(toBeFetched && install.fetch(toBeFetched));
 
-      ).then(function (tree) {
+      }).then(function (tree) {
         function both() {
           install(tree);
           clearPending();


### PR DESCRIPTION
Hi,

Previous PR kept failing and then I've noticed, that reify@0.17.2 was reverted, so I've changed test to represent reify@0.17.3 and bumped it in packages.json, hope that's ok with you.

Again, this is fix for https://github.com/meteor/meteor/issues/10182