### PR TITLE
Remove duplicate "license" key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "reify": "^0.18.1",
     "terser": "^3.16.0"
   },
-  "license": "MIT",
   "engines": {
     "node": ">= 0.10"
   }


### PR DESCRIPTION
This is breaking tooling that relies on `package.json` being a valid JSON file.